### PR TITLE
Fix for PHP 8.6.0alpha2

### DIFF
--- a/php_xz.h
+++ b/php_xz.h
@@ -42,6 +42,10 @@ extern php_stream_wrapper php_stream_xz_wrapper;
 #	include "TSRM.h"
 #endif
 
+#if PHP_VERSION_ID < 80600
+# define zend_ini_long_literal(name) zend_ini_long((name), sizeof("" name) - 1, 0)
+#endif
+
 php_stream *php_stream_xzopen(php_stream_wrapper *wrapper, const char *path, const char *mode_pass, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC);
 
 #endif	/* PHP_XZ_H */

--- a/xz.c
+++ b/xz.c
@@ -99,7 +99,7 @@ PHP_FUNCTION(xzopen)
 {
 	char *filename = NULL, *mode = NULL;
 	zend_long filename_len = 0, mode_len = 0;
-	zend_ulong compression_level = INI_INT("xz.compression_level");
+	zend_ulong compression_level = zend_ini_long_literal("xz.compression_level");
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss|l", &filename, &filename_len, &mode, &mode_len, &compression_level) == FAILURE) {
 		return;
@@ -127,7 +127,7 @@ PHP_FUNCTION(xzencode)
 	/* The length of the string to be encoded */
 	size_t in_len = 0;
 
-	zend_long compression_level = INI_INT("xz.compression_level");
+	zend_long compression_level = zend_ini_long_literal("xz.compression_level");
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &in, &in_len, &compression_level) == FAILURE) {
 		return;
@@ -242,7 +242,7 @@ PHP_FUNCTION(xzdecode)
 
 	/* Initializing decoder. */
 	lzma_stream strm = LZMA_STREAM_INIT;
-	uint64_t mem = INI_INT("xz.max_memory");
+	uint64_t mem = zend_ini_long_literal("xz.max_memory");
 	if (lzma_auto_decoder(&strm, mem ? mem : UINT64_MAX, LZMA_CONCATENATED) != LZMA_OK) {
 		RETURN_BOOL(0);
 	}

--- a/xz_fopen_wrapper.c
+++ b/xz_fopen_wrapper.c
@@ -366,8 +366,8 @@ php_stream_ops php_stream_xzio_ops = {
 php_stream *php_stream_xzopen(php_stream_wrapper *wrapper, const char *path, const char *mode_pass, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC)
 {
 	char mode[64];
-	zend_ulong level = INI_INT("xz.compression_level");;
-	zend_ulong mem = INI_INT("xz.max_memory");
+	zend_ulong level = zend_ini_long_literal("xz.compression_level");;
+	zend_ulong mem = zend_ini_long_literal("xz.max_memory");
 
 	php_stream *stream = NULL, *innerstream = NULL;
 


### PR DESCRIPTION
  . The INI_STR(), INI_INT(), INI_FLT(), and INI_BOOL() macros have been
    removed. Instead new zend_ini_{bool|long|double|str|string}_literal()
    macros have been added.